### PR TITLE
Fixes runtime when element on page exists with id="process"

### DIFF
--- a/argv.ts
+++ b/argv.ts
@@ -1,5 +1,4 @@
-export const argv =
-  typeof globalThis.process !== "undefined" ? globalThis.process.argv : []
+export const argv = globalThis.process?.argv || []
 
 export const getNonFlagArgvs = (cmd = argv[2]) =>
   argv.filter((arg) => !arg.startsWith("--")).slice(argv.indexOf(cmd) + 1)

--- a/env.ts
+++ b/env.ts
@@ -1,5 +1,4 @@
-export const getEnv = () =>
-  typeof globalThis.process !== "undefined" ? globalThis.process.env : {}
+export const getEnv = () => globalThis.process?.env || {}
 
 const DEFAULT_ENV_REGEX = /\$([\w+]+)/gm
 


### PR DESCRIPTION
In a script context, if you're on a page that has any element w/ `id="process"`, example: `<input id="process">` , `globalThis.process` will point to that element, which is wrong in this context.